### PR TITLE
small changes in the optical flow example

### DIFF
--- a/examples/optical_flow_LK.cpp
+++ b/examples/optical_flow_LK.cpp
@@ -43,40 +43,13 @@
 // it was created for displaying the optical flow in RGB
 struct OP_UVtoPolar {
   visioncpp::pixel::F32C3 operator()(visioncpp::pixel::F32C2 t) {
-    float intensity = cl::sycl::sqrt(t[0] * t[0] + t[1] * t[1]) / 2.0f;
+    float intensity = cl::sycl::clamp(
+        cl::sycl::sqrt(t[0] * t[0] + t[1] * t[1]) / 2.0f, 0.0f, 1.0f);
     float angle = cl::sycl::atan2(t[1], t[0]) / (2.0f * M_PI);
     float chn = 1.0f;
     return visioncpp::pixel::F32C3(angle, chn, intensity);
   }
 };
-
-// function to convert the (u,v) matrix to colors for displaying purposes
-template <size_t COLS, size_t ROWS, size_t SM, typename Device>
-void displayOpticalFlow(const std::shared_ptr<float> uv,
-                        std::shared_ptr<uchar> rgbFlow, Device &dev) {
-  // output node that will store the color information
-  auto out =
-      visioncpp::terminal<visioncpp::pixel::U8C3, COLS, ROWS,
-                          visioncpp::memory_type::Buffer2D>(rgbFlow.get());
-
-  // input UV
-  auto inUV = visioncpp::terminal<visioncpp::pixel::F32C2, COLS, ROWS,
-                                  visioncpp::memory_type::Buffer2D>(uv.get());
-  // convert UV into polar coordinates
-  auto polar = visioncpp::point_operation<OP_UVtoPolar>(inUV);
-
-  // convert into RGB
-  auto frgb = visioncpp::point_operation<visioncpp::OP_HSVToRGB>(polar);
-
-  // convert float to char
-  auto urgb = visioncpp::point_operation<visioncpp::OP_F32C3ToU8C3>(frgb);
-
-  // assign the urgb to the output node
-  auto k = visioncpp::assign(out, urgb);
-
-  // execute
-  visioncpp::execute<visioncpp::policy::Fuse, SM, SM, SM, SM>(k, dev);
-}
 
 // main program
 int main(int argc, char **argv) {
@@ -108,9 +81,7 @@ int main(int argc, char **argv) {
   float prewitt_y[9] = {-1.0f, -2.0f, -1.0f, 0.0, 0.0f, 0.0f, 1.0f, 2.0f, 1.0f};
 
   // initializing pointers which will store the final results
-  std::shared_ptr<float> outputUV(new float[COLS * ROWS * 2],
-                                  [](float *dataMem) { delete[] dataMem; });
-  std::shared_ptr<uchar> rgbflow(new uchar[COLS * ROWS * 3],
+  std::shared_ptr<uchar> rgbFlow(new uchar[COLS * ROWS * 3],
                                  [](uchar *dataMem) { delete[] dataMem; });
 
   // initializing matrices which will store current and previous frame
@@ -118,7 +89,7 @@ int main(int argc, char **argv) {
   cv::Mat previous;
 
   // init matrix which displays in RGB the (u,v) matrix
-  cv::Mat rgbflow_mat(ROWS, COLS, CV_8UC3, rgbflow.get());
+  cv::Mat rgbflow_mat(ROWS, COLS, CV_8UC3, rgbFlow.get());
 
   // flag to control if it is the first frame
   bool first = true;
@@ -151,9 +122,9 @@ int main(int argc, char **argv) {
       cv::resize(current, current, cv::Size(COLS, ROWS), 0, 0, cv::INTER_CUBIC);
 
       // init terminal nodes
-      auto outUV =
-          visioncpp::terminal<visioncpp::pixel::F32C2, COLS, ROWS,
-                              visioncpp::memory_type::Buffer2D>(outputUV.get());
+      auto out =
+          visioncpp::terminal<visioncpp::pixel::U8C3, COLS, ROWS,
+                              visioncpp::memory_type::Buffer2D>(rgbFlow.get());
 
       auto in =
           visioncpp::terminal<visioncpp::pixel::U8C3, COLS, ROWS,
@@ -277,7 +248,6 @@ int main(int argc, char **argv) {
           visioncpp::point_operation<visioncpp::OP_Mul>(ksumpx2, ksumpyt);
       auto pxtpxy_Sub_px2pyt =
           visioncpp::point_operation<visioncpp::OP_Sub>(pxtpxy, px2pyt);
-
       auto v = visioncpp::point_operation<visioncpp::OP_Div>(pxtpxy_Sub_px2pyt,
                                                              norm);
 
@@ -289,20 +259,28 @@ int main(int argc, char **argv) {
           visioncpp::point_operation<visioncpp::OP_Mul>(ksumpy2, ksumpxt);
       auto pxypft_Sub_py2pxt =
           visioncpp::point_operation<visioncpp::OP_Sub>(pxypyt, py2pxt);
-
       auto u = visioncpp::point_operation<visioncpp::OP_Div>(pxypft_Sub_py2pxt,
                                                              norm);
 
       // assign result in one matrix with 2 channels
+      // variable uv contains the optical flow computed for each pixel
       auto uv = visioncpp::point_operation<visioncpp::OP_Merge2Chns>(u, v);
 
-      auto kuv = visioncpp::assign(outUV, uv);
+      // The next operations were created to visualize the optical flow
+      // convert UV into polar coordinates
+      auto polar = visioncpp::point_operation<OP_UVtoPolar>(uv);
 
-      // execute expression tree
-      visioncpp::execute<visioncpp::policy::Fuse, SM, SM, SM, SM>(kuv, dev);
+      // convert into RGB
+      auto frgb = visioncpp::point_operation<visioncpp::OP_HSVToRGB>(polar);
 
-      // convert (u,v) matrix into colors for better visualization
-      displayOpticalFlow<COLS, ROWS, SM>(outputUV, rgbflow, dev);
+      // convert float to char
+      auto urgb = visioncpp::point_operation<visioncpp::OP_F32C3ToU8C3>(frgb);
+
+      // assign the urgb to the output node
+      auto k = visioncpp::assign(out, urgb);
+
+      // execute
+      visioncpp::execute<visioncpp::policy::Fuse, SM, SM, SM, SM>(k, dev);
     }
     // display optical flow
     cv::imshow("Reference Image", current);

--- a/examples/optical_flow_LK.cpp
+++ b/examples/optical_flow_LK.cpp
@@ -43,13 +43,40 @@
 // it was created for displaying the optical flow in RGB
 struct OP_UVtoPolar {
   visioncpp::pixel::F32C3 operator()(visioncpp::pixel::F32C2 t) {
-    float intensity = cl::sycl::clamp(
-        cl::sycl::sqrt(t[0] * t[0] + t[1] * t[1]) / 2.0f, 0.0f, 1.0f);
+    float intensity = cl::sycl::sqrt(t[0] * t[0] + t[1] * t[1]) / 2.0f;
     float angle = cl::sycl::atan2(t[1], t[0]) / (2.0f * M_PI);
     float chn = 1.0f;
     return visioncpp::pixel::F32C3(angle, chn, intensity);
   }
 };
+
+// function to convert the (u,v) matrix to colors for displaying purposes
+template <size_t COLS, size_t ROWS, size_t SM, typename Device>
+void displayOpticalFlow(const std::shared_ptr<float> uv,
+                        std::shared_ptr<uchar> rgbFlow, Device &dev) {
+  // output node that will store the color information
+  auto out =
+      visioncpp::terminal<visioncpp::pixel::U8C3, COLS, ROWS,
+                          visioncpp::memory_type::Buffer2D>(rgbFlow.get());
+
+  // input UV
+  auto inUV = visioncpp::terminal<visioncpp::pixel::F32C2, COLS, ROWS,
+                                  visioncpp::memory_type::Buffer2D>(uv.get());
+  // convert UV into polar coordinates
+  auto polar = visioncpp::point_operation<OP_UVtoPolar>(inUV);
+
+  // convert into RGB
+  auto frgb = visioncpp::point_operation<visioncpp::OP_HSVToRGB>(polar);
+
+  // convert float to char
+  auto urgb = visioncpp::point_operation<visioncpp::OP_F32C3ToU8C3>(frgb);
+
+  // assign the urgb to the output node
+  auto k = visioncpp::assign(out, urgb);
+
+  // execute
+  visioncpp::execute<visioncpp::policy::Fuse, SM, SM, SM, SM>(k, dev);
+}
 
 // main program
 int main(int argc, char **argv) {
@@ -81,7 +108,9 @@ int main(int argc, char **argv) {
   float prewitt_y[9] = {-1.0f, -2.0f, -1.0f, 0.0, 0.0f, 0.0f, 1.0f, 2.0f, 1.0f};
 
   // initializing pointers which will store the final results
-  std::shared_ptr<uchar> rgbFlow(new uchar[COLS * ROWS * 3],
+  std::shared_ptr<float> outputUV(new float[COLS * ROWS * 2],
+                                  [](float *dataMem) { delete[] dataMem; });
+  std::shared_ptr<uchar> rgbflow(new uchar[COLS * ROWS * 3],
                                  [](uchar *dataMem) { delete[] dataMem; });
 
   // initializing matrices which will store current and previous frame
@@ -89,7 +118,7 @@ int main(int argc, char **argv) {
   cv::Mat previous;
 
   // init matrix which displays in RGB the (u,v) matrix
-  cv::Mat rgbflow_mat(ROWS, COLS, CV_8UC3, rgbFlow.get());
+  cv::Mat rgbflow_mat(ROWS, COLS, CV_8UC3, rgbflow.get());
 
   // flag to control if it is the first frame
   bool first = true;
@@ -122,9 +151,9 @@ int main(int argc, char **argv) {
       cv::resize(current, current, cv::Size(COLS, ROWS), 0, 0, cv::INTER_CUBIC);
 
       // init terminal nodes
-      auto out =
-          visioncpp::terminal<visioncpp::pixel::U8C3, COLS, ROWS,
-                              visioncpp::memory_type::Buffer2D>(rgbFlow.get());
+      auto outUV =
+          visioncpp::terminal<visioncpp::pixel::F32C2, COLS, ROWS,
+                              visioncpp::memory_type::Buffer2D>(outputUV.get());
 
       auto in =
           visioncpp::terminal<visioncpp::pixel::U8C3, COLS, ROWS,
@@ -248,6 +277,7 @@ int main(int argc, char **argv) {
           visioncpp::point_operation<visioncpp::OP_Mul>(ksumpx2, ksumpyt);
       auto pxtpxy_Sub_px2pyt =
           visioncpp::point_operation<visioncpp::OP_Sub>(pxtpxy, px2pyt);
+
       auto v = visioncpp::point_operation<visioncpp::OP_Div>(pxtpxy_Sub_px2pyt,
                                                              norm);
 
@@ -259,28 +289,20 @@ int main(int argc, char **argv) {
           visioncpp::point_operation<visioncpp::OP_Mul>(ksumpy2, ksumpxt);
       auto pxypft_Sub_py2pxt =
           visioncpp::point_operation<visioncpp::OP_Sub>(pxypyt, py2pxt);
+
       auto u = visioncpp::point_operation<visioncpp::OP_Div>(pxypft_Sub_py2pxt,
                                                              norm);
 
       // assign result in one matrix with 2 channels
-      // variable uv contains the optical flow computed for each pixel
       auto uv = visioncpp::point_operation<visioncpp::OP_Merge2Chns>(u, v);
 
-      // The next operations were created to visualize the optical flow
-      // convert UV into polar coordinates
-      auto polar = visioncpp::point_operation<OP_UVtoPolar>(uv);
+      auto kuv = visioncpp::assign(outUV, uv);
 
-      // convert into RGB
-      auto frgb = visioncpp::point_operation<visioncpp::OP_HSVToRGB>(polar);
+      // execute expression tree
+      visioncpp::execute<visioncpp::policy::Fuse, SM, SM, SM, SM>(kuv, dev);
 
-      // convert float to char
-      auto urgb = visioncpp::point_operation<visioncpp::OP_F32C3ToU8C3>(frgb);
-
-      // assign the urgb to the output node
-      auto k = visioncpp::assign(out, urgb);
-
-      // execute
-      visioncpp::execute<visioncpp::policy::Fuse, SM, SM, SM, SM>(k, dev);
+      // convert (u,v) matrix into colors for better visualization
+      displayOpticalFlow<COLS, ROWS, SM>(outputUV, rgbflow, dev);
     }
     // display optical flow
     cv::imshow("Reference Image", current);


### PR DESCRIPTION
I changed size of summask in the optical flow example, for better results.
I removed 2 unnecessary schedules, since it was done just for a sequence of point operations.

EDIT: In the last commit I removed the function DisplayOpticalFlow to try to speed up the execution