### PR TITLE
Only build Doxygen docs on codeplay's repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - chmod +x ./scripts/travis_deploy_docs.sh
 
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./scripts/travis_build_docs.sh; fi'
+  - 'if [ "$TRAVIS_REPO_SLUG" = "codeplaysoftware/visioncpp" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash ./scripts/travis_build_docs.sh; fi'
 
 after_success:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./scripts/travis_deploy_docs.sh; fi'
+  - 'if [ "$TRAVIS_REPO_SLUG" = "codeplaysoftware/visioncpp" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bash ./scripts/travis_deploy_docs.sh; fi'


### PR DESCRIPTION
Use the Travis CI's [env vars](https://docs.travis-ci.com/user/environment-variables/) to disable doxygen builds on anything except Codeplay's master branch.

Issue #4.