### PR TITLE
Use container-based Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
-sudo: true
-dist: trusty
+sudo: false
 
 branches:
   except:


### PR DESCRIPTION
Travis is pushing for container-based builds as the recommended environment.

https://docs.travis-ci.com/user/migrating-from-legacy/

From what I can see there's nothing that requires sudo privileges and nothing should break. What do you think?