### PR TITLE
uplifting the template typename Device from member function level to …

### DIFF
--- a/include/framework/executor/policy/fuse.hpp
+++ b/include/framework/executor/policy/fuse.hpp
@@ -28,13 +28,12 @@ namespace visioncpp {
 namespace internal {
 /// \brief the FuseExpr when the expression type is not a terminal node
 /// (leafNode).
-template <size_t LCIn, size_t LRIn, size_t LCT, size_t LRT, typename Expr>
+template <size_t LCIn, size_t LRIn, size_t LCT, size_t LRT, typename Expr, typename DeviceT>
 struct FuseExpr {
   /// \brief the fuse function for executing the given expr.
   /// \param expr : the expression passed to be executed on the device
   /// \param dev : the selected device for executing the expression
   /// return void
-  template <typename DeviceT>
   static void fuse(Expr &expr, const DeviceT &dev) {
     /// LRT is the  workgroup size row and is checked with LR. LR is based
     /// on LRIn. LCT is the workgroup size column checked with LC. LC is based
@@ -67,11 +66,10 @@ struct FuseExpr {
 /// \brief specialisation of Fuse struct when the Expr is a terminal node
 /// (leafNode)
 template <size_t LC, size_t LR, size_t LCT, size_t LRT, size_t LVL,
-          typename RHS>
-struct FuseExpr<LC, LR, LCT, LRT, LeafNode<RHS, LVL>> {
+          typename RHS, typename DeviceT>
+struct FuseExpr<LC, LR, LCT, LRT, LeafNode<RHS, LVL>, DeviceT> {
   /// when the node is a terminal node (leafNode) we do nothing as there is no
   /// need to run any expression
-  template <typename DeviceT>
   static void fuse(LeafNode<RHS, LVL> &expr, const DeviceT &dev) {}
 };
 
@@ -89,7 +87,7 @@ struct FuseExpr<LC, LR, LCT, LRT, LeafNode<RHS, LVL>> {
 template <size_t LC, size_t LR, size_t LCT, size_t LRT, typename Expr,
           typename DeviceT>
 inline void fuse(Expr expr, const DeviceT &dev) {
-  FuseExpr<LC, LR, LCT, LRT, Expr>::fuse(expr, dev);
+  FuseExpr<LC, LR, LCT, LRT, Expr, DeviceT>::fuse(expr, dev);
 };
 }  // internal
 }  // visioncpp

--- a/include/framework/expr_tree/complex_ops/pyramid_with_auto_mem_gen.hpp
+++ b/include/framework/expr_tree/complex_ops/pyramid_with_auto_mem_gen.hpp
@@ -66,7 +66,7 @@ template <bool SatisfyingConds, typename Fltr2DOP, typename DownSmplOP,
           size_t Cols, size_t Rows, size_t LeafType, size_t OffsetCol,
           size_t OffsetRow, size_t LVL, size_t LC, size_t LR, size_t LRT,
           size_t LCT, size_t Depth, size_t CurrentDepth, typename LHS,
-          typename RHS, typename Fltr2D, typename PyramidMem>
+          typename RHS, typename Fltr2D, typename PyramidMem, typename DeviceT>
 struct PyramidExecuteAutoMemGen {
   /// function sub_execute
   /// \brief is the function used to construct a subexpression tree
@@ -77,7 +77,6 @@ struct PyramidExecuteAutoMemGen {
   /// \param mem: is the tuple of pyramid output memory
   /// \param dev : the selected device for executing the expression
   /// \return void
-  template <typename DeviceT>
   static void sub_execute(RHS &rhs, Fltr2D &fltr2D, PyramidMem &mem,
                           const DeviceT &dev) {
     // apply reduction
@@ -102,7 +101,7 @@ struct PyramidExecuteAutoMemGen {
         (Depth == (CurrentDepth + 1)), Fltr2DOP, DownSmplOP, Cols / 2, Rows / 2,
         LeafType, OffsetCol, OffsetRow + Rows / 2, RHSType::Level + 1, LC, LR,
         LCT, LRT, Depth, CurrentDepth + 1, LHS, RHSType, Fltr2D,
-        PyramidMem>::sub_execute(tools::tuple::get<CurrentDepth>(mem), fltr2D,
+        PyramidMem, DeviceT>::sub_execute(tools::tuple::get<CurrentDepth>(mem), fltr2D,
                                  mem, dev);
   }
 };
@@ -113,11 +112,10 @@ template <typename Fltr2DOP, typename DownSmplOP, size_t Cols, size_t Rows,
           size_t LeafType, size_t OffsetCol, size_t OffsetRow, size_t LVL,
           size_t LC, size_t LR, size_t LCT, size_t LRT, size_t Depth,
           size_t CurrentDepth, typename LHS, typename RHS, typename Fltr2D,
-          typename PyramidMem>
+          typename PyramidMem, typename DeviceT>
 struct PyramidExecuteAutoMemGen<
     true, Fltr2DOP, DownSmplOP, Cols, Rows, LeafType, OffsetCol, OffsetRow, LVL,
-    LC, LR, LCT, LRT, Depth, CurrentDepth, LHS, RHS, Fltr2D, PyramidMem> {
-  template <typename DeviceT>
+    LC, LR, LCT, LRT, Depth, CurrentDepth, LHS, RHS, Fltr2D, PyramidMem, DeviceT> {
   static void sub_execute(RHS &rhs, Fltr2D &fltr2D, PyramidMem &mem,
                           const DeviceT &dev) {}
 };
@@ -217,7 +215,7 @@ struct PyramidAutomemGen {
     PyramidExecuteAutoMemGen<
         Depth == 0, typename Fltr2DOP::OP, typename DownSmplOP::OP, Cols, Rows,
         LeafType, Cols, 0, 1 + LVL, LC, LR, LCT, LRT, Depth, 0, LHSExpr,
-        decltype(eval_sub), Fltr2D, PyramidMem>::sub_execute(eval_sub, fltr2D,
+        decltype(eval_sub), Fltr2D, PyramidMem, DeviceT>::sub_execute(eval_sub, fltr2D,
                                                              mem, dev);
     return get<0>();
   }

--- a/include/framework/expr_tree/complex_ops/pyramid_with_auto_mem_sep.hpp
+++ b/include/framework/expr_tree/complex_ops/pyramid_with_auto_mem_sep.hpp
@@ -68,7 +68,7 @@ template <bool SatisfyingConds, typename SepFltrColOP, typename SepFltrRowOP,
           size_t OffsetCol, size_t OffsetRow, size_t LVL, size_t LC, size_t LR,
           size_t LCT, size_t LRT, size_t Depth, size_t CurrentDepth,
           typename LHS, typename RHS, typename SepFilterCol,
-          typename SepFilterRow, typename PyramidMem>
+          typename SepFilterRow, typename PyramidMem, typename DeviceT>
 struct PyramidExecuteAutoMemSep {
   /// function sub_execute
   /// \brief is the function used to construct a subexpression tree
@@ -80,7 +80,6 @@ struct PyramidExecuteAutoMemSep {
   /// \param mem: is the tuple of pyramid output memory
   /// \param dev : the selected device for executing the expression
   /// \return void
-  template <typename DeviceT>
   static void sub_execute(RHS &rhs, SepFilterCol &spFltrCol,
                           SepFilterRow &spFltrRow, PyramidMem &mem,
                           const DeviceT &dev) {
@@ -113,7 +112,7 @@ struct PyramidExecuteAutoMemSep {
         Cols / 2, Rows / 2, LeafType, OffsetCol, OffsetRow + Rows / 2,
         RHSType::Level + 1, LC, LR, LCT, LRT, Depth, CurrentDepth + 1, LHS,
         RHSType, SepFilterCol, SepFilterRow,
-        PyramidMem>::sub_execute(tools::tuple::get<CurrentDepth>(mem),
+        PyramidMem, DeviceT>::sub_execute(tools::tuple::get<CurrentDepth>(mem),
                                  spFltrCol, spFltrRow, mem, dev);
   }
 };
@@ -126,12 +125,11 @@ template <typename SepFltrColOP, typename SepFltrRowOP, typename DownSmplOP,
           size_t OffsetRow, size_t LVL, size_t LC, size_t LR, size_t LRT,
           size_t LCT, size_t Depth, size_t CurrentDepth, typename LHS,
           typename RHS, typename SepFilterCol, typename SepFilterRow,
-          typename PyramidMem>
+          typename PyramidMem, typename DeviceT>
 struct PyramidExecuteAutoMemSep<true, SepFltrColOP, SepFltrRowOP, DownSmplOP,
                                 Cols, Rows, LeafType, OffsetCol, OffsetRow, LVL,
                                 LC, LR, LCT, LRT, Depth, CurrentDepth, LHS, RHS,
-                                SepFilterCol, SepFilterRow, PyramidMem> {
-  template <typename DeviceT>
+                                SepFilterCol, SepFilterRow, PyramidMem, DeviceT> {
   static void sub_execute(RHS &, SepFilterCol &, SepFilterRow &, PyramidMem &,
                           const DeviceT &) {}
 };
@@ -240,7 +238,7 @@ struct PyramidAutomemSep {
         Depth == 0, typename SepFltrColOP::OP, typename SepFltrRowOP::OP,
         typename DownSmplOP::OP, Cols, Rows, LeafType, Cols, 0, 1 + LVL, LC, LR,
         LCT, LRT, Depth, 0, LHSExpr, decltype(eval_sub), SepFilterCol,
-        SepFilterRow, PyramidMem>::sub_execute(eval_sub, spFltrCol, spFltrRow,
+        SepFilterRow, PyramidMem, DeviceT>::sub_execute(eval_sub, spFltrCol, spFltrRow,
                                                mem, dev);
     return get<0>();
   }

--- a/include/framework/expr_tree/point_ops/parallel_copy.hpp
+++ b/include/framework/expr_tree/point_ops/parallel_copy.hpp
@@ -127,7 +127,7 @@ struct ParallelCopy {
         rhs.template sub_expression_evaluation<false, LC, LR, LCT, LRT>(dev);
     // through template instantiation it executes the kernel when it is a leaf node.
     auto intermediate_output =
-        SubExprRes<LC, LR, LCT, LRT, 1 + LVL, decltype(eval_sub)>::get(eval_sub,
+        SubExprRes<LC, LR, LCT, LRT, 1 + LVL, decltype(eval_sub), DeviceT>::get(eval_sub,
                                                                        dev);
     internal::fuse<LC, LR, LCT, LRT>(
         internal::ParallelCopy<

--- a/include/framework/forward_declarations.hpp
+++ b/include/framework/forward_declarations.hpp
@@ -162,7 +162,7 @@ struct Assign;
 
 /// \brief The definition is in \ref SubExprRes file.
 template <size_t LC, size_t LR, size_t LCT, size_t LRT, size_t LVL,
-          typename Expr>
+          typename Expr,typename DeviceT>
 struct SubExprRes;
 
 template <size_t LC, size_t LR, size_t LCT, size_t LRT, typename Expr,


### PR DESCRIPTION
Uplifting the "template <typename Device>" from member function level to the struct level in order to specialise those structs for different devices. This is necessary for future support of different backends such as OpenMP.