### PR TITLE
README: Fix formatting of Overview header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
   <br /><img src="https://www.codeplay.com/public/uploaded/public/computevision.png"><br />
 </div>
+
 # Overview
 **VisionCpp** is a lightweight header-only library for computer vision and image processing.
 The aim of the library is to provide a toolbox that enables performance portability for heterogeneous platforms using modern C++.


### PR DESCRIPTION
This patch adds a newline between the VisionCpp header logo and the Overview header text, in order to fix parsing of the README as GitHub Flavored Markdown.

As it stands, the Overview header text is currently not parsed as a header, and the `#` symbol is left untouched by the parser. Additionally, the "VisionCpp" text on the following line is not parsed as bold, and the asterisks are left untouched.